### PR TITLE
Feature/puma single mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Usage of mackerel-plugin-puma:
     	Temp file name
   -token string
     	The token to use as authentication for the control server
+  -single
+    	Monitor Puma in single mode
   -with-gc
     	Output include GC stats for Puma 3.10.0~
 ```
@@ -30,7 +32,7 @@ Usage of mackerel-plugin-puma:
 
 ```
 [plugin.metrics.puma]
-command = "/opt/mackerel-agent/plugins/bin/mackerel-plugin-puma -token=12345 --with-gc"
+command = "/opt/mackerel-agent/plugins/bin/mackerel-plugin-puma -token=12345 --single --with-gc"
 ```
 
 ## Screenshot

--- a/lib/puma.go
+++ b/lib/puma.go
@@ -12,6 +12,7 @@ type PumaPlugin struct {
 	Host   string
 	Port   string
 	Token  string
+	Single bool
 	WithGC bool
 }
 
@@ -84,6 +85,7 @@ func Do() {
 		optHost     = flag.String("host", "127.0.0.1", "The bind url to use for the control server")
 		optPort     = flag.String("port", "9293", "The bind port to use for the control server")
 		optToken    = flag.String("token", "", "The token to use as authentication for the control server")
+		optSingle   = flag.Bool("single", false, "Puma in single mode")
 		optWithGC   = flag.Bool("with-gc", false, "Output include GC stats for Puma 3.10.0~")
 		optTempfile = flag.String("tempfile", "", "Temp file name")
 	)
@@ -94,6 +96,7 @@ func Do() {
 	puma.Host = *optHost
 	puma.Port = *optPort
 	puma.Token = *optToken
+	puma.Single = *optSingle
 	puma.WithGC = *optWithGC
 
 	helper := mp.NewMackerelPlugin(puma)

--- a/lib/stat.go
+++ b/lib/stat.go
@@ -61,6 +61,9 @@ type Stats struct {
 			Running int `json:"running"`
 		} `json:"last_status"`
 	} `json:"worker_status"`
+	// Single mode
+	Backlog int `json:"backlog"`
+	Running int `json:"running"`
 }
 
 // GET request to /stats
@@ -88,6 +91,12 @@ func (p PumaPlugin) getStatsAPI() (*Stats, error) {
 // Fetch /stats
 func (p PumaPlugin) fetchStatsMetrics(stats *Stats) map[string]float64 {
 	ret := make(map[string]float64)
+
+	if p.Single == true {
+		ret["backlog.worker0.backlog"] = float64(stats.Backlog)
+		ret["running.worker0.running"] = float64(stats.Running)
+		return ret
+	}
 
 	ret["workers"] = float64(stats.Workers)
 	ret["spawn_workers"] = float64(stats.BootedWorkers)


### PR DESCRIPTION
Add support for Puma in Single mode.
The default is Cluster mode, Single mode is optional.

This is because the json format returned by Puma's Control Server differs between Cluster mode and Single mode.