### PR TITLE
Support Unix Domain Socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,12 @@ Usage of mackerel-plugin-puma:
 command = "/opt/mackerel-agent/plugins/bin/mackerel-plugin-puma -token=12345 --single --with-gc"
 ```
 
+For unix domain socket:
+
+```
+[plugin.metrics.puma]
+command = "/opt/mackerel-agent/plugins/bin/mackerel-plugin-puma -sock /path/to/pumactl.socket -token=12345 --single --with-gc"
+```
+
 ## Screenshot
 ![Screenshot](./docs/images/ss.png)

--- a/lib/gc.go
+++ b/lib/gc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	mp "github.com/mackerelio/go-mackerel-plugin"
@@ -112,8 +113,20 @@ func (p PumaPlugin) getGCStatsAPI() (*GCStats, error) {
 
 	var gcStats GCStats
 
+	var client http.Client
+
+	if p.Sock != "" {
+		client = http.Client{Transport: &http.Transport{
+			Dial: func(proto, addr string) (conn net.Conn, err error) {
+				return net.Dial("unix", p.Sock)
+			},
+		}}
+	} else {
+		client = http.Client{}
+	}
+
 	uri := fmt.Sprintf("http://%s:%s/%s?token=%s", p.Host, p.Port, "gc-stats", p.Token)
-	resp, err := http.Get(uri)
+	resp, err := client.Get(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/puma.go
+++ b/lib/puma.go
@@ -11,6 +11,7 @@ type PumaPlugin struct {
 	Prefix string
 	Host   string
 	Port   string
+	Sock   string
 	Token  string
 	Single bool
 	WithGC bool
@@ -88,6 +89,7 @@ func Do() {
 		optPrefix   = flag.String("metric-key-prefix", "puma", "Metric key prefix")
 		optHost     = flag.String("host", "127.0.0.1", "The bind url to use for the control server")
 		optPort     = flag.String("port", "9293", "The bind port to use for the control server")
+		optSock     = flag.String("sock", "", "The bind socket to use for the control server")
 		optToken    = flag.String("token", "", "The token to use as authentication for the control server")
 		optSingle   = flag.Bool("single", false, "Puma in single mode")
 		optWithGC   = flag.Bool("with-gc", false, "Output include GC stats for Puma 3.10.0~")
@@ -99,6 +101,7 @@ func Do() {
 	puma.Prefix = *optPrefix
 	puma.Host = *optHost
 	puma.Port = *optPort
+	puma.Sock = *optSock
 	puma.Token = *optToken
 	puma.Single = *optSingle
 	puma.WithGC = *optWithGC

--- a/lib/stat.go
+++ b/lib/stat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -88,8 +89,20 @@ func (p PumaPlugin) getStatsAPI() (*Stats, error) {
 
 	var stats Stats
 
+	var client http.Client
+
+	if p.Sock != "" {
+		client = http.Client{Transport: &http.Transport{
+			Dial: func(proto, addr string) (conn net.Conn, err error) {
+				return net.Dial("unix", p.Sock)
+			},
+		}}
+	} else {
+		client = http.Client{}
+	}
+
 	uri := fmt.Sprintf("http://%s:%s/%s?token=%s", p.Host, p.Port, "stats", p.Token)
-	resp, err := http.Get(uri)
+	resp, err := client.Get(uri)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch propose to support unix domain socket because you can set unix domain socket to control url like `puma -C unix:///path/to/pumactl.socket`.
